### PR TITLE
Add Deploy to Remote Branch feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,22 @@ Inspired by [BryanSchuetz/jekyll-deploy-gh-pages](https://github.com/BryanSchuet
 
 - `HUGO_VERSION` : **optional**, default is **0.54.0** - [check all versions here](https://github.com/gohugoio/hugo/releases)
 
+- `GITHUB_BRANCH` : **optional**, default is **gh-pages**
+
+- `GITHUB_REMOTE_REPOSITORY` : **optional**, default is **GITHUB_REPOSITORY**
+
+
 ## Example
 
 **push.yml** (New syntax)
 
+**Deploy to gp-pages branch**: (under same repo)
+
 ```yaml
-on: push
 name: Deploy to GitHub Pages
+
+on: push
+
 jobs:
   hugo-deploy-gh-pages:
     runs-on: ubuntu-latest
@@ -37,6 +46,33 @@ jobs:
         GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
         HUGO_VERSION: "0.53"
 ```
+
+
+**Deploy to Remote Branch**:
+
+```yaml
+name: Deploy to Remote Branch
+
+on:
+  push:
+    branches:
+      - master
+      
+jobs:
+  hugo-deploy-gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: hugo-deploy-gh-pages
+      uses: khanhicetea/gh-actions-hugo-deploy-gh-pages@master
+      env:
+        GITHUB_REMOTE_REPOSITORY: <username>/<remote_repository_name>
+        GITHUB_BRANCH: <custom_branch>
+        GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
+        HUGO_VERSION: "0.58.3"
+```
+
+**Note**: make sure to add `GIT_DEPLOY_KEY` in secrets of mentioned `GITHUB_REMOTE_REPOSITORY`
 
 **main.workflow** (Old syntax - deprecated)
 
@@ -53,6 +89,7 @@ action "hugo-deploy-gh-pages" {
   ]
   env = {
     HUGO_VERSION = "0.53"
+    GITHUB_BRANCH = "master"
   }
 }
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 echo '=================== Install Hugo ==================='
 DOWNLOAD_HUGO_VERSION=${HUGO_VERSION:-0.54.0}
+GITHUB_DEPLOY_REPOSITORY=${GITHUB_REMOTE_REPOSITORY:-GITHUB_REPOSITORY}
+GITHUB_DEPLOY_BRANCH=${GITHUB_BRANCH:-"gh-pages"}
 echo "Installing Hugo $DOWNLOAD_HUGO_VERSION"
 wget -O /tmp/hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v${DOWNLOAD_HUGO_VERSION}/hugo_extended_${DOWNLOAD_HUGO_VERSION}_Linux-64bit.tar.gz &&\
 tar -zxf /tmp/hugo.tar.gz -C /tmp &&\
@@ -18,8 +20,9 @@ echo '=================== Build site ==================='
 HUGO_ENV=production hugo -v --minify -d dist
 echo '=================== Publish to GitHub Pages ==================='
 cd dist
-remote_repo="git@github.com:${GITHUB_REPOSITORY}.git" && \
-remote_branch="gh-pages" && \
+remote_repo="git@github.com:${GITHUB_DEPLOY_REPOSITORY}.git" && \
+remote_branch=${GITHUB_DEPLOY_BRANCH} && \
+echo "Pushing Builds to $remote_repo:$remote_branch" && \
 git init && \
 git remote add deploy $remote_repo && \
 git checkout $remote_branch || git checkout --orphan $remote_branch && \
@@ -29,7 +32,7 @@ git add . && \
 echo -n 'Files to Commit:' && ls -l | wc -l && \
 timestamp=$(date +%s%3N) && \
 git commit -m "Automated deployment to GitHub Pages on $timestamp" > /dev/null 2>&1 && \
-git push deploy $remote_branch --force > /dev/null 2>&1 && \
+git push deploy $remote_branch --force && \
 rm -fr .git && \
 cd ../
 echo '=================== Done  ==================='


### PR DESCRIPTION
This PR, 
- adds GITHUB_BRANCH environment variable to push generated sites into custom branches.
- adds GITHUB_REMOTE_REPOSITORY environment variable to push generated sites into remote repositories.
- updates README.md with docs and examples

fixes: #2 