### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Inspired by [BryanSchuetz/jekyll-deploy-gh-pages](https://github.com/BryanSchuet
 
 **push.yml** (New syntax)
 
-**Deploy to gp-pages branch**: (under same repo)
+**Deploy to gh-pages branch**: (under same repo)
 
 ```yaml
 name: Deploy to GitHub Pages


### PR DESCRIPTION
Hello @khanhicetea. 

In pull-requests #3, the line including wrong typo seems be added. (see [pull/3/README.md#31](https://github.com/khanhicetea/gh-actions-hugo-deploy-gh-pages/pull/3/files#diff-04c6e90faac2675aa89e2176d2eec7d8R31)).

Isn't it right *gh-pages*, not *gp-pages* ?